### PR TITLE
Add support for Haiku lights

### DIFF
--- a/Examples/fastDimLights.js
+++ b/Examples/fastDimLights.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 // Don't scan for any fans since we know the exact address of the fan (faster!)
 var myMaster = new bigAssApi.FanMaster(0); 

--- a/Examples/fastDimLights.js
+++ b/Examples/fastDimLights.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
 // Don't scan for any fans since we know the exact address of the fan (faster!)
 var myMaster = new bigAssApi.FanMaster(0); 

--- a/Examples/getFanInfo.js
+++ b/Examples/getFanInfo.js
@@ -1,8 +1,8 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
-var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
+var myMaster = new bigAssApi.FanMaster(1); // Expect only one device in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
-	console.log("Found a new fan with name '" + myBigAss.name + "'")
+myMaster.onDeviceFullyUpdated = function(myBigAss){
+	console.log("Found a new device with name '" + myBigAss.name + "'")
 	console.log("and identifier: '" + myBigAss.id + "'\n")
 }

--- a/Examples/getFanInfo.js
+++ b/Examples/getFanInfo.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/largerExample.js
+++ b/Examples/largerExample.js
@@ -1,10 +1,10 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 bigAssApi.logging = false;
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
 console.log("Waiting for full update");
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Filter out all fants that don't begin with "Sean" - that's in my fan's name!
 	var lowercaseName = myBigAss.name.toLowerCase();

--- a/Examples/largerExample.js
+++ b/Examples/largerExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 bigAssApi.logging = false;
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup

--- a/Examples/simpleExample.js
+++ b/Examples/simpleExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/simpleExample.js
+++ b/Examples/simpleExample.js
@@ -1,8 +1,8 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Will automatically update / retry setting for this connected fan
     myBigAss.light.brightness = 1;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Unofficial Big Ass API
 ======================
-This is this an unofficial Node.js API for [Big Ass Fans - fans with SenseME](www.bigassfans.com).
-
-In particular - all development was done on a Haiku fan with SenseME.
+This is this an unofficial Node.js API for [Big Ass Fans and lights with SenseME](www.bigassfans.com).
 
 What this could be/is used for
 ------------------------------
@@ -12,28 +10,28 @@ What this could be/is used for
 
 Using the API!
 ==============
-Two major components - the FanMaster and the BigAssFan.
+Three major components - the FanMaster, the BigAssLight, and the BigAssFan.
 
 FanMaster
 ---------
- - Listens for new fans
- - Allows sending messages to all fans
- - Routes all incoming messages to the appropriate child fans
- - Retries fan searching if fans detected < fans specified in constructor
- - Will not search for any fans if 0 is passed into constructor
+ - Listens for new devices
+ - Allows sending messages to all devices
+ - Routes all incoming messages to the appropriate child devices
+ - Retries device searching if devices detected < devices specified in constructor
+ - Will not search for any devices if 0 is passed into constructor
 
 Every fan needs a `FanMaster`! Because that's where the messages come from!
 
 ### Usage
- - Initialize with: `new bigAssApi.FanMaster(numberOfExpectedFans)`
+ - Initialize with: `new bigAssApi.FanMaster(numberOfExpectedDevices)`
  	- Will continue to query for new fans until numberOfExpectedFans is met - default is 1
- - `onFanFullyUpdated` - callback you can override - called with every new fully initialized fan
- - `onFanConnection` - callback you can override - called with every new fan connection with the fan connected
- 	- Will get called before onFanFullyUpdated - but not guaranteed to have all fields updated (some will be `undefined`)
- - `rescanForFans` - rescans for all fans
- - `rescanUntilAllFans` - continues rescanning until `fanMaster.numberOfExpectedFans >= fansFound`
- - `allFans` - dictionary containing all of the fans - keyed off of the user given name
- - `pollingIntervalForFans` - polling interval if `numberOfExpectedFans < fansFound`
+ - `onDeviceFullyUpdated` - callback you can override - called with every new fully initialized device
+ - `onDeviceConnection` - callback you can override - called with every new device connection with the device connected
+ 	- Will get called before `onDeviceFullyUpdated` - but not guaranteed to have all fields updated (some will be `undefined`)
+ - `rescanForDevices` - rescans for all fans
+ - `rescanUntilAllDevices` - continues rescanning until `fanMaster.numberOfExpectedDevices >= fansFound`
+ - `allDevices` - dictionary containing all of the devices - keyed off of the user given name
+ - `pollingIntervalForDevices` - polling interval if `numberOfExpectedDevices < devicesFound`
 
 BigAssFan
 ---------
@@ -56,7 +54,7 @@ var bigAssApi = require("BigAssFansAPI");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Will automatically update / retry setting for this connected fan
     myBigAss.light.brightness = 1;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Every fan needs a `FanMaster`! Because that's where the messages come from!
 
 BigAssFan
 ---------
- - Allows sending and recieving messages from the fan
+ - Allows sending and receiving messages from the fan
  - Registering for property updates
  - Sending update events to a given property
  - Implementing retries on setting properties

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BigAssFansAPI",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "An unofficial API for BigAssFans",
   "main": "src/BigAssApi.js",
   "repository": {

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -6,7 +6,7 @@ const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
 function FanMaster (numberOfExpectedDevices) {
     this.allDevices = {}; // Dictionary of fan name -> BigAssDevice
-    this.sonnectionOpen = false;
+    this.connectionOpen = false;
     this.fanPort = 31415;
     this.everyone = "255.255.255.255";
     this.server = dgram.createSocket("udp4");


### PR DESCRIPTION
Ok, working on updates from what @stabbylambda started. I know there were concerns about having significant changes to the API, but with my experience working at Nest, this is for the best. It is likely that Big Ass Inc will expand into more products, and switching to generic terms sooner will make the overall API cleaner in the future.

I verified the examples with my three devices (one fan/light and two standalone lights) and everything is working as expected. Ideally there would be support for identifying device type, but I am going to hold off on that until I look at the Homebridge side of things.

As for Homebridge, I have already create a [PR](https://github.com/sean9keenan/homebridge-bigAssFans/pull/19) to update the plugin so it will lock to the appropriate version of the API module. The sooner that can ship the better.